### PR TITLE
Update to use new Scotty 0.5.0 transformers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This is still work-in-progress
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
- 
+
 import Text.Hastache
-import Web.Scotty as S
+import Web.Scotty.Trans as S
 import Web.Scotty.Hastache
- 
+
 main :: IO ()
 main = scottyH 3000 $ do
   setTemplatesDir "templates"
@@ -36,13 +36,11 @@ Installation
 =========
 
 1. Install GHC, Haskell platform, etc
-2. Install my fork of Scotty:
-  you need to checkout the `scotty-transformer` branch.
+2. Install Scotty >= 0.5.0. Currently:
 
   ```
-  $ git clone https://github.com/co-dan/scotty.git
-  $ cd scotty 
-  $ git checkout scotty-transformer
+  $ git clone https://github.com/xich/scotty.git
+  $ cd scotty
   $ cabal install
   ```
 3. Install hastache:

--- a/examples/hastachetest.hs
+++ b/examples/hastachetest.hs
@@ -3,13 +3,13 @@
 module Main where
 
 import Text.Hastache
-import Web.Scotty as S
+import Web.Scotty.Trans as S
 import Web.Scotty.Hastache
 
 main :: IO ()
 main = scottyH 3000 $ do
   setTemplatesDir "templates"
-  
+
   get "/:word" $ do
     beam <- param "word"
     setH "action" $ MuVariable (beam :: String)

--- a/scotty-hastache.cabal
+++ b/scotty-hastache.cabal
@@ -1,7 +1,7 @@
 name:                scotty-hastache
 version:             0.1.0.0
 synopsis:            Easy Hastache templating support for Scotty
--- description:         
+-- description:
 license:             BSD3
 license-file:        LICENSE
 author:              Dan Frumin
@@ -14,29 +14,25 @@ cabal-version:       >=1.10
 
 extra-source-files:  examples/hastachetest.hs
                      examples/templates/greet.html
-                     
+
 library
   exposed-modules:     Web.Scotty.Hastache
-  build-depends:       base            >= 4.4 && < 5,          
-                       blaze-builder   >= 0.3.1.0, 
-                       blaze-html      >= 0.6.0.0,    
-                       blaze-markup    >= 0.5.1.0,  
-                       bytestring      >= 0.9.1,    
-                       containers      >= 0.5.0.0,    
-                       data-default    >= 0.5.0,  
-                       filepath        >= 1.3.0.0,      
-                       hastache        >= 0.5.0,      
-                       http-types      >= 0.7.3.0.1,    
-                       mmorph          == 1.*,        
-                       mtl             >= 2.1.2,           
-                       scotty          >= 0.4.6.1,        
+  build-depends:       base            >= 4.4 && < 5,
+                       blaze-html      >= 0.6.0.0,
+                       blaze-markup    >= 0.5.1.0,
+                       containers      >= 0.5.0.0,
+                       filepath        >= 1.3.0.0,
+                       hastache        >= 0.5.0,
+                       http-types      >= 0.7.3.0.1,
+                       mtl             >= 2.1.2,
+                       scotty          >= 0.5.0,
                        wai             >= 1.3.0.1,
-                       warp            >= 1.3.4.1         
-                       
+                       warp            >= 1.3.4.1
+
 
 
   hs-source-dirs:      src
-  GHC-options:         -Wall -Werror -fno-warn-orphans 
+  GHC-options:         -Wall -Werror -fno-warn-orphans
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
Here is a patch that allows scotty-hastache to use Scotty's new transformer stuff. You'll probably want to review my definitions of `runH` and `runActionToIO` to make sure what I did with the state is correct. (It appeared that the state wasn't saved at the end of each action, so I didn't do that.) In this case, you could probably use a simple IORef instead of an MVar.

I've updated the example and tested it. I haven't tried to see what needs changing in interactive-diagrams.
