### PR TITLE
Fix the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import Web.Scotty.Hastache
 
 main :: IO ()
 main = scottyH' 3000 $ do
-  templates "templates"
+  setTemplatesDir "templates"
   -- ^ Setting up the director with templates
   get "/:word" $ do
     beam <- param "word"


### PR DESCRIPTION
It seems the `templates` function has been renamed to `setTemplatesDir`.
This fixes the `README` example to avoid confusion - even though the
Haddock documentation will point the user to the correct name.
